### PR TITLE
Fixed menu behavior

### DIFF
--- a/acerca_thermonox.html
+++ b/acerca_thermonox.html
@@ -117,18 +117,18 @@
 			  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 			  <li class="offcanvas_nav__item">
 				<a href="./acerca_thermonox.html">THERMONOX®</a>
-				  <ul class="navbar__dropdown">
-					<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-					<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-					<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+				  <ul class="offcanvas_subnav">
+					<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+					<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+					<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 				  </ul>
 			  </li>
 			  <li class="offcanvas_nav__item">
 				<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-				  <ul class="navbar__dropdown">
-					<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-					<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-					<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+				  <ul class="offcanvas_subnav">
+					<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+					<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+					<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 				  </ul>
 			  </li>
 			  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/acerca_thermonoxilo.html
+++ b/acerca_thermonoxilo.html
@@ -118,18 +118,18 @@
 			  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 			  <li class="offcanvas_nav__item">
 				<a href="./acerca_thermonox.html">THERMONOX®</a>
-				  <ul class="navbar__dropdown">
-					<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-					<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-					<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+				  <ul class="offcanvas_subnav">
+					<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+					<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+					<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 				  </ul>
 			  </li>
 			  <li class="offcanvas_nav__item">
 				<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-				  <ul class="navbar__dropdown">
-					<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-					<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-					<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+				  <ul class="offcanvas_subnav">
+					<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+					<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+					<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 				  </ul>
 			  </li>
 			  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/aplicacion_thermonoxilo.html
+++ b/aplicacion_thermonoxilo.html
@@ -94,18 +94,18 @@
 				  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonox.html">THERMONOX®</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-						<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-						<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/aplicaciones.html
+++ b/aplicaciones.html
@@ -147,18 +147,18 @@
 				  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonox.html">THERMONOX®</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-						<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-						<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -10,11 +10,14 @@
 
 html{
     height: 100%;
+    background-color: var(--brown);
 }
 
 body{
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
+    background-color: white;
     color: var(--grey);
     font-family: 'Montserrat';
     min-height: 100%;
@@ -25,6 +28,7 @@ body{
 .body--offcanvas{
     transform: translateX(270px);
     overflow: hidden;
+    height: 100vh;
 }
 
 ul{
@@ -64,6 +68,13 @@ ul{
     flex-grow: 1;
 }
 
+.menu-icon{
+    color: white;
+    font-size: 32px;
+    position: absolute;
+    left: 0;
+}
+
 .header__logo_container{
     display: block;
     width: 280px;
@@ -79,26 +90,26 @@ ul{
     display: none;
 }
 
-.menu-icon{
-    color: white;
-    font-size: 32px;
-    position: absolute;
-    left: 0;
-}
 .navbar{
     display: none;
 }
 
 .offcanvas{
+    display: none;
     color: white;
     position: absolute;
     left: -270px;
     background-color: var(--brown);
-    height: 100vh;
+    height: 0;
     width: 270px;
     overflow: auto;
     line-height: 22px;
     z-index: 11;
+}
+
+.offcanvas--show{
+    height: 100vh;
+    display: block;
 }
 
 .offcanvas a{
@@ -149,20 +160,6 @@ ul{
     min-height: 100vh;
     width: 100vw;
     z-index: 1;
-}
-
-.offcanvas_nav__item a:hover{
-    background-color: var(--orange);
-}
-
-.dropdown__option a{
-    display: flex;
-    padding: 5px 20px;
-    color: white;
-}
-
-.dropdown__option a:hover{
-    background-color: var(--orange);
 }
 
 .cover--show{

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,9 +1,13 @@
+window.scrollTo({ top: 0});
+const offcanvas = document.querySelector(".offcanvas")
 const body = document.querySelector("body");
 const cover = document.getElementById("cover");
 const menuButton = document.getElementById("menu-icon");
 
 const toggleMenu = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
   body.classList.toggle("body--offcanvas");
+  offcanvas.classList.toggle("offcanvas--show");
   cover.classList.toggle("cover--show");
 }
 

--- a/contacto.html
+++ b/contacto.html
@@ -151,18 +151,18 @@
 				  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonox.html">THERMONOX®</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-						<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-						<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/funcionamiento.html
+++ b/funcionamiento.html
@@ -175,18 +175,18 @@
 				  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonox.html">THERMONOX®</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-						<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-						<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/index.html
+++ b/index.html
@@ -137,18 +137,18 @@
       <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
       <li class="offcanvas_nav__item">
         <a href="./acerca_thermonox.html">THERMONOX®</a>
-          <ul class="navbar__dropdown">
-            <li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-            <li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-            <li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+          <ul class="offcanvas_subnav">
+            <li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+            <li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+            <li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
           </ul>
       </li>
       <li class="offcanvas_nav__item">
         <a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-          <ul class="navbar__dropdown">
-            <li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-            <li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-            <li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+          <ul class="offcanvas_subnav">
+            <li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+            <li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+            <li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
           </ul>
       </li>
       <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/seguridad.html
+++ b/seguridad.html
@@ -96,18 +96,18 @@
 				  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonox.html">THERMONOX®</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-						<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-						<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>

--- a/seguridad_thermonoxilo.html
+++ b/seguridad_thermonoxilo.html
@@ -83,18 +83,18 @@
 				  <li class="offcanvas_nav__item offcanvas_nav__item--selected"><a href="./index.html">Inicio</a></li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonox.html">THERMONOX®</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./funcionamiento.html">Funcionamiento</a></li>
-						<li class="dropdown__option"><a href="./aplicaciones.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./funcionamiento.html">Funcionamiento</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicaciones.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item">
 					<a href="./acerca_thermonoxilo.html">THERMONOXILO</a>
-					  <ul class="navbar__dropdown">
-						<li class="dropdown__option"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
-						<li class="dropdown__option"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
-						<li class="dropdown__option"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
+					  <ul class="offcanvas_subnav">
+						<li class="offcanvas_subnav__item"><a href="./acerca_thermonoxilo.html">Acerca de ThermoNoxilo</a></li>
+						<li class="offcanvas_subnav__item"><a href="./aplicacion_thermonoxilo.html">Aplicaciones</a></li>
+						<li class="offcanvas_subnav__item"><a href="./seguridad_thermonoxilo.html">Seguridad</a></li>
 					  </ul>
 				  </li>
 				  <li class="offcanvas_nav__item"><a href="./contacto.html">Contacto</a></li>


### PR DESCRIPTION
Cambie los estilos del menu de mobile, ya que en algunas pantallas (horizontales con altura menor al menu) el menu ser rompía, también volví a poner en el menu mobile los class name offcanvas_subnav y offcanvas_subnav__item en lugar de navabar__dropdown y dropdown__option ya que estos últimos ya estaban designados a los estilos de los dropdown del menu desktop.